### PR TITLE
Fix: 'Play from beginning' does not work with Jellyfin add-on.

### DIFF
--- a/1080i/IncludesDialogVideoInfo.xml
+++ b/1080i/IncludesDialogVideoInfo.xml
@@ -491,7 +491,7 @@
                                 <!-- play episode -->
                                 <onclick condition="!Control.IsVisible(5050) + String.IsEqual(ListItem.DBTYPE,episode) + !String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia(videodb://tvshows/$INFO[ListItem.DBID]),00:01,silent)</onclick>
                                 <!-- play movie -->
-                                <onclick condition="!Control.IsVisible(5050) + String.IsEqual(ListItem.DBTYPE,movie) + !String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia(videodb://movies/$INFO[ListItem.DBID]),00:01,silent)</onclick>
+                                <onclick condition="!Control.IsVisible(5050) + !String.IsEmpty(ListItem.FileNameAndPath) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia($ESCINFO[ListItem.FileNameAndPath],noresume),00:01,silent)</onclick>
                                 <!-- fallback to native play button -->
                                 <onclick condition="!Control.IsVisible(1234) + [String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,movie)] + String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia($INFO[ListItem.FileNameAndPath],noresume),00:01,silent)</onclick>
                                 <!-- only if FILE FOLDERS structured with seasons folders -->
@@ -1765,7 +1765,7 @@
                                 <!-- play episode -->
                                 <onclick condition="!Control.IsVisible(5050) + String.IsEqual(ListItem.DBTYPE,episode) + !String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia(videodb://tvshows/$INFO[ListItem.DBID]),00:01,silent)</onclick>
                                 <!-- play movie -->
-                                <onclick condition="!Control.IsVisible(5050) + String.IsEqual(ListItem.DBTYPE,movie) + !String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia(videodb://movies/$INFO[ListItem.DBID]),00:01,silent)</onclick>
+                                <onclick condition="!Control.IsVisible(5050) + !String.IsEmpty(ListItem.FileNameAndPath) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia($ESCINFO[ListItem.FileNameAndPath],noresume),00:01,silent)</onclick>
                                 <!-- fallback to native play button -->
                                 <onclick condition="!Control.IsVisible(1234) + [String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,movie)] + String.IsEmpty(ListItem.DBID) + !Window.IsActive(Custom_1190_TMDbBingieHelperCast.xml)">AlarmClock(PlayMovie,PlayMedia($INFO[ListItem.FileNameAndPath],noresume),00:01,silent)</onclick>
                                 <!-- only if FILE FOLDERS structured with seasons folders -->


### PR DESCRIPTION
There's an issue with the `Play from beginning` button when using Bingie skin. For some reason it can not find the media content type using the current call. 
This PR fixes that problem.
<img width="1045" height="155" alt="image" src="https://github.com/user-attachments/assets/bb767a1b-bbe4-4600-85ce-074c6591706d" />

<img width="1035" height="644" alt="image" src="https://github.com/user-attachments/assets/a9c5b4c6-c0ac-4910-a46a-973dd164d726" />

<img width="1035" height="644" alt="image" src="https://github.com/user-attachments/assets/4befa35c-08e1-413d-9e7a-a170c3364f35" />
